### PR TITLE
Fix libhandy_window_plugin.so's RUNPATH

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -30,6 +30,11 @@ if(GLIB_FOUND)
   add_subdirectory(libhandy)
   add_definitions(-DHAVE_LIBHANDY)
   target_link_libraries(${PLUGIN_NAME} PRIVATE handy)
+  set_target_properties(${PLUGIN_NAME}
+    PROPERTIES
+    INSTALL_RPATH "$ORIGIN"
+    BUILD_WITH_INSTALL_RPATH TRUE
+  )
 else()
   message(WARNING "The `handy_window` package requires libglib2.0-0 >= 2.58 available in Ubuntu 20.04 and later. Using normal Flutter window instead.")
 endif()


### PR DESCRIPTION
This ensures that it will find `libhandy_flutter.so`:

```
$ objdump -p build/linux/x64/release/bundle/lib/libhandy_window_plugin.so
...
Dynamic Section:
  NEEDED               libhandy_flutter.so
  ...
  SONAME               libhandy_window_plugin.so
  RUNPATH              $ORIGIN
  ...
```