### PR TITLE
Fix crash on close

### DIFF
--- a/linux/handy_window_plugin.cc
+++ b/linux/handy_window_plugin.cc
@@ -77,8 +77,14 @@ static gboolean hdy_window_draw(GtkWidget* widget, cairo_t* cr) {
 }
 
 static void hdy_window_destroy(GtkWidget* widget) {
-  hdy_window_mixin_destroy(get_window_mixin(widget));
-  gtk_window_destroy(widget);
+  if (IS_REENTRY(widget)) {
+    fprintf(stderr, "Reentrancy detected in hdy_window_destroy\n");
+    gtk_window_destroy(widget);
+  } else {
+    GUARD_REENTRY(widget);
+    fprintf(stderr, "hdy_window_destroy\n");
+    hdy_window_mixin_destroy(get_window_mixin(widget));
+  }
 }
 
 static void hdy_window_finalize(GObject* object) {


### PR DESCRIPTION
Guard hdy_window_destroy() against reentrancy to avoid an infinite
loop, because it would be called back from HdyWindowMixin:
```
Thread 1 "handy_window_ex" received signal SIGSEGV, Segmentation fault.
0x00007ffff4e8e3d5 in ?? () from /lib/x86_64-linux-gnu/libgobject-2.0.so.0
(gdb) bt
#0  0x00007ffff4e8e3d5 in  () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#1  0x00007ffff4e919ff in g_type_check_instance_cast () at /lib/x86_64-linux-gnu/libgobject-2.0.so.0
#2  0x00007ffff7fb5295 in HDY_WINDOW_MIXIN(void*) (ptr=0x555555a16c90)
    at /home/jpnurmi/Projects/ubuntu/handy_window/example/linux/flutter/ephemeral/.plugin_symlinks/handy_window/linux/libhandy/src/src/hdy-window-mixin-private.h:19
#3  0x00007ffff7fb5261 in get_window_mixin(void*) (object=0x55555576c2c0)
    at /home/jpnurmi/Projects/ubuntu/handy_window/example/linux/flutter/ephemeral/.plugin_symlinks/handy_window/linux/handy_window_plugin.cc:29
#4  0x00007ffff7fb4e25 in hdy_window_destroy(_GtkWidget*) (widget=0x55555576c2c0)
    at /home/jpnurmi/Projects/ubuntu/handy_window/example/linux/flutter/ephemeral/.plugin_symlinks/handy_window/linux/handy_window_plugin.cc:80
#5  0x00007ffff47892b2 in hdy_window_mixin_destroy (self=0x555555a16c90)
    at /home/jpnurmi/Projects/ubuntu/handy_window/example/linux/flutter/ephemeral/.plugin_symlinks/handy_window/linux/libhandy/src/src/hdy-window-mixin.c:478
#6  0x00007ffff7fb4e2d in hdy_window_destroy(_GtkWidget*) (widget=0x55555576c2c0)
    at /home/jpnurmi/Projects/ubuntu/handy_window/example/linux/flutter/ephemeral/.plugin_symlinks/handy_window/linux/handy_window_plugin.cc:80
#7  0x00007ffff47892b2 in hdy_window_mixin_destroy (self=0x555555a16c90)
    at /home/jpnurmi/Projects/ubuntu/handy_window/example/linux/flutter/ephemeral/.plugin_symlinks/handy_window/linux/libhandy/src/src/hdy-window-mixin.c:478
#8  0x00007ffff7fb4e2d in hdy_window_destroy(_GtkWidget*) (widget=0x55555576c2c0)
    at /home/jpnurmi/Projects/ubuntu/handy_window/example/linux/flutter/ephemeral/.plugin_symlinks/handy_window/linux/handy_window_plugin.cc:80
#9  0x00007ffff47892b2 in hdy_window_mixin_destroy (self=0x555555a16c90)
    at /home/jpnurmi/Projects/ubuntu/handy_window/example/linux/flutter/ephemeral/.plugin_symlinks/handy_window/linux/libhandy/src/src/hdy-window-mixin.c:478
#10 0x00007ffff7fb4e2d in hdy_window_destroy(_GtkWidget*) (widget=0x55555576c2c0)
    at /home/jpnurmi/Projects/ubuntu/handy_window/example/linux/flutter/ephemeral/.plugin_symlinks/handy_window/linux/handy_window_plugin.cc:80
[...]
```