### PR TITLE
Enforce private "-Wall -Wextra -Werror" compiler options for the plugin

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(${PLUGIN_NAME} SHARED
 apply_standard_settings(${PLUGIN_NAME})
 set_target_properties(${PLUGIN_NAME} PROPERTIES
   CXX_VISIBILITY_PRESET hidden)
+target_compile_options(${PLUGIN_NAME} PRIVATE -Wall -Wextra -Werror)
 target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
 target_include_directories(${PLUGIN_NAME} INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/include")


### PR DESCRIPTION
This ensures that the plugin compiles for apps that themselves set
stricter compiler options.