### PR TITLE
Check for CSD support & respect the GTK_CSD environment variable

### DIFF
--- a/linux/handy_window_plugin.cc
+++ b/linux/handy_window_plugin.cc
@@ -146,8 +146,29 @@ static gboolean sanity_check_view(FlView* view) {
   return true;
 }
 
+static gboolean use_csd(GtkWidget* window) {
+  // the screen must be composited and support alpha visuals for the shadow
+  GdkScreen* screen = gtk_window_get_screen(GTK_WINDOW(window));
+  if (!gdk_screen_is_composited(screen) ||
+      !gdk_screen_get_rgba_visual(screen)) {
+    return false;
+  }
+
+  // disable if GTK_CSD != 1
+  const gchar* gtk_csd = g_getenv("GTK_CSD");
+  if (gtk_csd != nullptr && g_strcmp0(gtk_csd, "1") != 0) {
+    return false;
+  }
+
+  return true;
+}
+
 static void setup_handy_window(FlView* view) {
   GtkWidget* window = gtk_widget_get_toplevel(GTK_WIDGET(view));
+
+  if (!use_csd(window)) {
+    return;
+  }
 
   if (!sanity_check_window(window) || !sanity_check_view(view)) {
     g_warning(


### PR DESCRIPTION
Don't use a handy window with CSD shadows if the screen is not composited or there's no support for alpha visuals. Furthermore, respect the `GTK_CSD` environment variable to allow disabling handy window.