### PR TITLE
Fix missing close button on non-GNOME X11 platforms

### DIFF
--- a/linux/handy_window_plugin.cc
+++ b/linux/handy_window_plugin.cc
@@ -188,6 +188,7 @@ static void setup_handy_window(FlView* view) {
   } else if (title != nullptr) {
     header_bar = hdy_header_bar_new();
     hdy_header_bar_set_title(HDY_HEADER_BAR(header_bar), title);
+    hdy_header_bar_set_show_close_button(HDY_HEADER_BAR(header_bar), TRUE);
     gtk_window_set_title(GTK_WINDOW(window), nullptr);
   }
   if (header_bar != nullptr) {


### PR DESCRIPTION
| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/140617/205136718-4dcda56d-f119-49a7-b279-a0bab44f04d7.png) | ![image](https://user-images.githubusercontent.com/140617/205136518-064c3314-677e-4cd4-be5f-e63b0e836ae4.png) |

Ref: #12