### PR TITLE
Add option to use libhandy without widget tree manipulation

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -26,6 +26,7 @@ target_link_libraries(${PLUGIN_NAME} PRIVATE PkgConfig::GTK)
 
 # libhandy requires g_atomic_ref_count_init/inc/dec available since 2.58
 pkg_check_modules(GLIB glib-2.0>=2.58)
+
 if(GLIB_FOUND)
   # List of absolute paths to libraries that should be bundled with the plugin
   set(handy_window_bundled_libraries
@@ -33,9 +34,13 @@ if(GLIB_FOUND)
     PARENT_SCOPE
   )
 
+  if(USE_LIBHANDY)
+    target_compile_definitions(${PLUGIN_NAME} PRIVATE USE_LIBHANDY)
+  endif()
+
   add_subdirectory(libhandy)
-  add_definitions(-DHAVE_LIBHANDY)
-  target_link_libraries(${PLUGIN_NAME} PRIVATE handy)
+  target_compile_definitions(${PLUGIN_NAME} PUBLIC HAVE_LIBHANDY)
+  target_link_libraries(${PLUGIN_NAME} PUBLIC handy)
   set_target_properties(${PLUGIN_NAME}
     PROPERTIES
     INSTALL_RPATH "$ORIGIN"

--- a/linux/handy_window_plugin.cc
+++ b/linux/handy_window_plugin.cc
@@ -1,6 +1,6 @@
 #include "include/handy_window/handy_window_plugin.h"
 
-#if HAVE_LIBHANDY
+#ifdef HAVE_LIBHANDY
 
 #include <flutter_linux/flutter_linux.h>
 #include <gtk/gtk.h>
@@ -10,6 +10,7 @@
 
 #include "handy_settings.h"
 
+#ifndef USE_LIBHANDY
 #define _HANDY_INSIDE
 #include "hdy-window-mixin-private.h"
 #undef _HANDY_INSIDE
@@ -147,6 +148,7 @@ static gboolean sanity_check_view(FlView* view) {
   }
   return true;
 }
+#endif  // USE_LIBHANDY
 
 static gboolean use_csd(GtkWidget* window) {
   // the screen must be composited and support alpha visuals for the shadow
@@ -203,6 +205,7 @@ static void setup_handy_window(FlView* view) {
     return;
   }
 
+#ifndef USE_LIBHANDY
   if (!sanity_check_window(window) || !sanity_check_view(view)) {
     g_warning(
         "Setting up a Handy window failed. A normal GTK window will be used "
@@ -275,6 +278,7 @@ static void setup_handy_window(FlView* view) {
     gtk_widget_show(header_bar);
   }
   gtk_widget_show(GTK_WIDGET(view));
+#endif  // USE_LIBHANDY
 
   // css
   HandySettings* settings = handy_settings_new();


### PR DESCRIPTION
In `linux/CMakeLists.txt`:

```cmake
set(USE_LIBHANDY ON)
```

In `linux/my_application.cc`:

```c
static void foo() {
  hdy_init();
  GtkWidget* window = hdy_application_window_new();
  ...
}
```

Ref: #27