### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.3.0
+
+* Update dependency yaru to ^0.5.0 by @renovate in https://github.com/ubuntu-flutter-community/handy_window/pull/25
+* Add option to use libhandy without widget tree manipulation by @jpnurmi in https://github.com/ubuntu-flutter-community/handy_window/pull/28
+* Revert shadow to Gtk3 one by @Jupi007 in https://github.com/ubuntu-flutter-community/handy_window/pull/29
+
 # 0.2.1
 
 * Compile stylesheet using sass (#21).

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: |
 homepage: https://github.com/ubuntu-flutter-community/handy_window
 repository: https://github.com/ubuntu-flutter-community/handy_window
 issue_tracker: https://github.com/ubuntu-flutter-community/handy_window/issues
-version: 0.2.1
+version: 0.3.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
* Update dependency yaru to ^0.5.0 by @renovate in https://github.com/ubuntu-flutter-community/handy_window/pull/25
* Add option to use libhandy without widget tree manipulation by @jpnurmi in https://github.com/ubuntu-flutter-community/handy_window/pull/28
* Revert shadow to Gtk3 one by @Jupi007 in https://github.com/ubuntu-flutter-community/handy_window/pull/29