### PR TITLE
Bump Yaru to 9.0 to fix build with recent Flutter

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   handy_window:
     path: ../
   url_launcher: ^6.1.0
-  yaru: ^4.0.0
+  yaru: ^9.0.0
 
 dev_dependencies:
   flutter_lints: ^2.0.0


### PR DESCRIPTION
Building the example project fails with following error (with recent Flutter):
```
ERROR: ../../../../../../.pub-cache/hosted/pub.dev/yaru-4.1.0/lib/src/themes/common_themes.dart:712:18: Error: The argument type 'TabBarTheme' can't be assigned to the parameter type 'TabBarThemeData?'.
ERROR:  - 'TabBarTheme' is from 'package:flutter/src/material/tab_bar_theme.dart' ('../../../flutter/flutter-stable/flutter/packages/flutter/lib/src/material/tab_bar_theme.dart').
ERROR:  - 'TabBarThemeData' is from 'package:flutter/src/material/tab_bar_theme.dart' ('../../../flutter/flutter-stable/flutter/packages/flutter/lib/src/material/tab_bar_theme.dart').
ERROR:     tabBarTheme: _createTabBarTheme(colorScheme, dividerColor),
ERROR:                  ^
ERROR: ../../../../../../.pub-cache/hosted/pub.dev/yaru-4.1.0/lib/src/themes/common_themes.dart:713:18: Error: The argument type 'DialogTheme' can't be assigned to the parameter type 'DialogThemeData?'.
ERROR:  - 'DialogTheme' is from 'package:flutter/src/material/dialog_theme.dart' ('../../../flutter/flutter-stable/flutter/packages/flutter/lib/src/material/dialog_theme.dart').
ERROR:  - 'DialogThemeData' is from 'package:flutter/src/material/dialog_theme.dart' ('../../../flutter/flutter-stable/flutter/packages/flutter/lib/src/material/dialog_theme.dart').
ERROR:     dialogTheme: _createDialogTheme(colorScheme),
ERROR:                  ^
ERROR: ../../../../../../.pub-cache/hosted/pub.dev/yaru-4.1.0/lib/src/themes/common_themes.dart:766:24: Error: The argument type 'BottomAppBarTheme' can't be assigned to the parameter type 'BottomAppBarThemeData?'.
ERROR:  - 'BottomAppBarTheme' is from 'package:flutter/src/material/bottom_app_bar_theme.dart' ('../../../flutter/flutter-stable/flutter/packages/flutter/lib/src/material/bottom_app_bar_theme.dart').
ERROR:  - 'BottomAppBarThemeData' is from 'package:flutter/src/material/bottom_app_bar_theme.dart' ('../../../flutter/flutter-stable/flutter/packages/flutter/lib/src/material/bottom_app_bar_theme.dart').
ERROR:     bottomAppBarTheme: BottomAppBarTheme(color: colorScheme.surface),
ERROR:                        ^
ERROR: Target kernel_snapshot_program failed: Exception
Building Linux application...
Build process failed
```

Bumping yaru from 4.0 to 9.0 fixes the issue:
```
Building Linux application...
✓ Built build/linux/x64/release/bundle/handy_window_example
```